### PR TITLE
Added 'Expr Strings'

### DIFF
--- a/src/quaz/compiler/CliHandler.java
+++ b/src/quaz/compiler/CliHandler.java
@@ -135,7 +135,7 @@ public class CliHandler {
 
 			Lexer lexer = new Lexer();
 
-			Token[] tokens = lexer.lex(f, text);
+			Token[] tokens = lexer.lex(f, text, null);
 
 			if(lex) {
 				Arrays.asList(tokens).forEach(System.out::println);

--- a/src/quaz/compiler/compiler/preprocessors/ValueVisitor.java
+++ b/src/quaz/compiler/compiler/preprocessors/ValueVisitor.java
@@ -23,4 +23,6 @@ public class ValueVisitor {
 	
 	public void visitShortNode(Node node, Context context) {}
 	
+	public void visitExprStringNode(Node node, Context context) {}
+	
 }

--- a/src/quaz/compiler/lexer/ExprStringToken.java
+++ b/src/quaz/compiler/lexer/ExprStringToken.java
@@ -1,0 +1,18 @@
+package quaz.compiler.lexer;
+
+import quaz.compiler.position.Position;
+
+public class ExprStringToken extends Token {
+	
+	private final Token[][] exprs;
+	
+	public ExprStringToken(Token[][] exprs, String value, Position start, Position end) {
+		super(TokenType.EXPR_STRING, value, start, end);
+		this.exprs = exprs;
+	}
+
+	public Token[][] getExprs() {
+		return exprs;
+	}
+	
+}

--- a/src/quaz/compiler/lexer/TokenType.java
+++ b/src/quaz/compiler/lexer/TokenType.java
@@ -9,6 +9,7 @@ public enum TokenType {
 	DOUBLE,
 	FLOAT,
 	STRING,
+	EXPR_STRING,
 	CHAR,
 	BYTE,
 	LONG,

--- a/src/quaz/compiler/parser/nodes/value/ExprStringNode.java
+++ b/src/quaz/compiler/parser/nodes/value/ExprStringNode.java
@@ -1,0 +1,40 @@
+package quaz.compiler.parser.nodes.value;
+
+import java.util.List;
+
+import quaz.compiler.lexer.Token;
+import quaz.compiler.parser.nodes.Node;
+
+public class ExprStringNode extends Node {
+	
+	private final Node[] exprs;
+	private final String rep;
+	
+	public ExprStringNode(String value, Node[] exprs, Token token) {
+		super(value, token.getStart(), token.getEnd());
+		this.exprs = exprs;
+		this.rep = value;
+	}
+
+	public String getRep() {
+		return rep;
+	}
+
+	public Node[] getExprs() {
+		return exprs;
+	}
+	
+	@Override
+	public String toString() {
+		String val = rep;
+		
+		List<Node> exprsList = List.of(exprs);
+		
+		for(Node expr : exprsList) {
+			val = val.replaceFirst("\u0001", "${" + expr.toString() + "}");
+		}
+		
+		return val;
+	}
+	
+}


### PR DESCRIPTION
These are the "${expr}" syntax for strings. They do not require the use of different quotes (still use double quotes) and they can be eascaped by writing "\${}" which will produce "${}".

Any expression can be placed within them, but not statements.